### PR TITLE
Adding logging around spawning and killing Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-## [Unreleased](https://github.com/rubycdp/ferrum/compare/v0.12...main) ##
+## [Unreleased](https://github.com/rubycdp/ferrum/compare/v0.13...main) ##
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.13](https://github.com/rubycdp/ferrum/compare/v0.12...v0.13) - (Nov 12, 2022) ##
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## [Unreleased](https://github.com/rubycdp/ferrum/compare/v0.13...main) ##
 
 ### Added
+- `Ferrum::Network::Exchange#xhr?` determines if the exchange is XHR
+- `Ferrum::Network::Request#xhr?` determines if the request is XHR
+- `Ferrum::Network::Response#loaded?` returns true if the response is fully loaded
 
 ### Changed
 
 ### Fixed
+- `Ferrum::Network::Exchange#finished?` returns `true` only fully loaded responses
 
 ### Removed
 

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -34,14 +34,14 @@ module Ferrum
             ::Process.kill("KILL", pid) unless system("taskkill /f /t /pid #{pid} >NUL 2>NUL")
           else
             ::Process.kill("USR1", pid)
-            logger&.puts("\nAttemping to kill chrome (#{pid})")
+            logger&.puts("\nAttemping to kill #{pid}")
             start = Utils::ElapsedTime.monotonic_time
             while ::Process.wait(pid, ::Process::WNOHANG).nil?
-              logger&.puts("Waiting for chrome (#{pid}) to end")
+              logger&.puts("Waiting for #{pid} to end")
               sleep(WAIT_KILLED)
               next unless Utils::ElapsedTime.timeout?(start, KILL_TIMEOUT)
 
-              logger&.puts("Forcefully killing chrome (#{pid})")
+              logger&.puts("Forcefully killing #{pid}")
               ::Process.kill("KILL", pid)
               ::Process.wait(pid)
               break

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -90,12 +90,12 @@ module Ferrum
         if ENV["FERRUM_CHROME_LOG"]
           File.open(ENV["FERRUM_CHROME_LOG"], "w") do |output_log|
             launch_chrome(stdout_and_stderr: output_log)
-            File.open(output_log.path, "r") do |read_from_log|
+            File.open(output_log.path, "r:#{Encoding.default_external}") do |read_from_log|
               parse_ws_url(read_from_log, @process_timeout, @pid)
             end
           end
         else
-          IO.pipe do |read_io, write_io|
+          IO.pipe(Encoding.default_external) do |read_io, write_io|
             begin
               launch_chrome(stdout_and_stderr: write_io)
               parse_ws_url(read_io, @process_timeout, @pid)

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -9,7 +9,6 @@ require "ferrum/browser/options/base"
 require "ferrum/browser/options/chrome"
 require "ferrum/browser/options/firefox"
 require "ferrum/browser/command"
-require "pry"
 
 module Ferrum
   class Browser

--- a/lib/ferrum/browser/process.rb
+++ b/lib/ferrum/browser/process.rb
@@ -186,10 +186,10 @@ module Ferrum
           end
         end
 
+        @logger&.puts("chrome (#{pid}) IO stream output: #{output}***\n")
         return if ws_url
 
         log_chrome_ps(pid, "\nNo websocket detected for chrome")
-        @logger&.puts("chrome (#{pid}) IO stream output: #{output}***\n")
         raise ProcessTimeoutError.new(timeout, output)
       end
 

--- a/lib/ferrum/frame.rb
+++ b/lib/ferrum/frame.rb
@@ -113,6 +113,7 @@ module Ferrum
         document.close();
         arguments[1](true);
       ), @page.timeout, html)
+      @page.document_node_id
     end
     alias set_content content=
 

--- a/lib/ferrum/network.rb
+++ b/lib/ferrum/network.rb
@@ -374,8 +374,12 @@ module Ferrum
 
     def subscribe_loading_finished
       @page.on("Network.loadingFinished") do |params|
-        exchange = select(params["requestId"]).last
-        exchange.response.body_size = params["encodedDataLength"] if exchange&.response
+        response = select(params["requestId"]).last&.response
+
+        if response
+          response.loaded = true
+          response.body_size = params["encodedDataLength"]
+        end
       end
     end
 

--- a/lib/ferrum/network/exchange.rb
+++ b/lib/ferrum/network/exchange.rb
@@ -79,7 +79,7 @@ module Ferrum
       # @return [Boolean]
       #
       def finished?
-        blocked? || !response.nil? || !error.nil?
+        blocked? || response&.loaded? || !error.nil?
       end
 
       #
@@ -98,6 +98,15 @@ module Ferrum
       #
       def intercepted?
         !intercepted_request.nil?
+      end
+
+      #
+      # Determines if the exchange is XHR.
+      #
+      # @return [Boolean]
+      #
+      def xhr?
+        !!request&.xhr?
       end
 
       #

--- a/lib/ferrum/network/request.rb
+++ b/lib/ferrum/network/request.rb
@@ -51,6 +51,15 @@ module Ferrum
       end
 
       #
+      # Determines if the request is XHR.
+      #
+      # @return [Boolean]
+      #
+      def xhr?
+        type?("xhr")
+      end
+
+      #
       # The frame ID of the request.
       #
       # @return [String]

--- a/lib/ferrum/network/response.rb
+++ b/lib/ferrum/network/response.rb
@@ -18,8 +18,13 @@ module Ferrum
       # @return [Hash{String => Object}]
       attr_reader :params
 
+      # The response is fully loaded by the browser.
       #
-      # Initializes the respones object.
+      # @return [Boolean]
+      attr_writer :loaded
+
+      #
+      # Initializes the responses object.
       #
       # @param [Page] page
       #   The page associated with the network response.
@@ -121,9 +126,8 @@ module Ferrum
       #
       def body
         @body ||= begin
-          body, encoded = @page
-                          .command("Network.getResponseBody", requestId: id)
-                          .values_at("body", "base64Encoded")
+          body, encoded = @page.command("Network.getResponseBody", requestId: id)
+                               .values_at("body", "base64Encoded")
           encoded ? Base64.decode64(body) : body
         end
       end
@@ -133,6 +137,13 @@ module Ferrum
       #
       def main?
         @page.network.response == self
+      end
+
+      # The response is fully loaded by the browser or not.
+      #
+      # @return [Boolean]
+      def loaded?
+        @loaded
       end
 
       #

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -325,6 +325,10 @@ module Ferrum
       use_proxy? && @proxy_user && @proxy_password
     end
 
+    def document_node_id
+      command("DOM.getDocument", depth: 0).dig("root", "nodeId")
+    end
+
     private
 
     def subscribe
@@ -439,10 +443,6 @@ module Ferrum
       end
 
       (nil_or_relative ? @browser.base_url.join(url.to_s) : url).to_s
-    end
-
-    def document_node_id
-      command("DOM.getDocument", depth: 0).dig("root", "nodeId")
     end
 
     def ws_url

--- a/lib/ferrum/version.rb
+++ b/lib/ferrum/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ferrum
-  VERSION = "0.13"
+  VERSION = "0.13.1"
 end

--- a/spec/frame_spec.rb
+++ b/spec/frame_spec.rb
@@ -181,9 +181,10 @@ describe Ferrum::Frame do
   end
 
   it "can set page content" do
-    browser.content = "<html><head></head><body>Voila!</body></html>"
+    browser.content = "<html><head></head><body>Voila! <a href='#'>Link</a></body></html>"
 
     expect(browser.body).to include("Voila!")
+    expect(browser.at_css("a").text).to eq("Link")
   end
 
   it "gets page doctype" do

--- a/spec/network/response_spec.rb
+++ b/spec/network/response_spec.rb
@@ -81,7 +81,7 @@ describe Ferrum::Network::Response do
         %r{/ferrum/jquery.min.js$} => File.size("#{PROJECT_ROOT}/spec/support/public/jquery-1.11.3.min.js"),
         %r{/ferrum/jquery-ui.min.js$} => File.size("#{PROJECT_ROOT}/spec/support/public/jquery-ui-1.11.4.min.js"),
         %r{/ferrum/test.js$} => File.size("#{PROJECT_ROOT}/spec/support/public/test.js"),
-        %r{/ferrum/with_js$} => 2343
+        %r{/ferrum/with_js$} => 2312
       }
 
       resources_size.each do |resource, size|

--- a/spec/support/views/animated.erb
+++ b/spec/support/views/animated.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>

--- a/spec/support/views/attach_file.erb
+++ b/spec/support/views/attach_file.erb
@@ -1,10 +1,10 @@
 <script>
-window.onload = function() {
-  var file = document.getElementById("file")
-  file.onchange = function() {
-    file.parentElement.removeChild(file)
+  window.onload = function() {
+    var file = document.getElementById("file")
+    file.onchange = function() {
+      file.parentElement.removeChild(file)
+    }
   }
-}
 </script>
 
 <input type="file" id="file">

--- a/spec/support/views/auto_refresh.erb
+++ b/spec/support/views/auto_refresh.erb
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
   </head>

--- a/spec/support/views/buttons.erb
+++ b/spec/support/views/buttons.erb
@@ -1,4 +1,3 @@
-
 <h1>Buttons</h1>
 <button>Click me!</button>
 <button id="click_me_123">Click me by id!</button>

--- a/spec/support/views/click_coordinates.erb
+++ b/spec/support/views/click_coordinates.erb
@@ -1,30 +1,30 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <style type="text/css">
-    body {
-      width: 800px;
-      margin: 0;
-    }
-    #box {
-      width: 800px;
-      height: 600px;
-      background: red;
-    }
-  </style>
-  <script type="text/javascript">
-  window.onload = function() {
-    var log = document.querySelector("#log")
-    var boxes = document.querySelector("#box")
-    boxes.onclick = function(event) {
-      var text = "x: " + event.pageX + ", y: " + event.pageY;
-      log.textContent = text
-    }
-  }
-  </script>
-</head>
-<body>
-  <div id="box"></div>
-  <div id="log"></div>
-</body>
+  <head>
+    <style>
+      body {
+        width: 800px;
+        margin: 0;
+      }
+      #box {
+        width: 800px;
+        height: 600px;
+        background: red;
+      }
+    </style>
+    <script type="text/javascript">
+      window.onload = function() {
+        var log = document.querySelector("#log")
+        var boxes = document.querySelector("#box")
+        boxes.onclick = function(event) {
+          var text = "x: " + event.pageX + ", y: " + event.pageY;
+          log.textContent = text
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <div id="box"></div>
+    <div id="log"></div>
+  </body>
 </html>

--- a/spec/support/views/click_test.erb
+++ b/spec/support/views/click_test.erb
@@ -1,52 +1,52 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <style type="text/css">
-    body {
-      width: 800px;
-      margin: 0;
-    }
-    .box {
-      width: 200px;
-      height: 200px;
-      float: left;
-      margin: 100px;
-    }
-    #one {
-      background: red;
-    }
-    #two {
-      background: orange
-    }
-    #three {
-      background: blue;
-    }
-    #four {
-      background: green;
-    }
-  </style>
-  <script type="text/javascript">
-  window.onload = function() {
-    var log = document.querySelector("#log")
-    var boxes = document.querySelectorAll(".box")
-    for (var i = 0; i < boxes.length; i++) {
-      var el = boxes[i]
-      el.onclick = function() {
-        log.textContent = this.id
+  <head>
+    <style>
+      body {
+        width: 800px;
+        margin: 0;
       }
-    }
-  }
-  </script>
-</head>
-<body>
-  <div id="one" class="box"></div>
-  <div id="two" class="box"></div>
-  <div id="three" class="box"></div>
-  <div id="four" class="box"></div>
-  <div id="log"></div>
-  <svg id="svg" class="box"></svg>
-  <svg xmlns="http://www.w3.org/2000/svg" version="1.1">
-    <rect id="myrect" width="300" height="100" style="fill:rgb(0,0,255);stroke-width:1;stroke:rgb(0,0,0)" />
-  </svg>
-</body>
+      .box {
+        width: 200px;
+        height: 200px;
+        float: left;
+        margin: 100px;
+      }
+      #one {
+        background: red;
+      }
+      #two {
+        background: orange
+      }
+      #three {
+        background: blue;
+      }
+      #four {
+        background: green;
+      }
+    </style>
+    <script type="text/javascript">
+      window.onload = function() {
+        var log = document.querySelector("#log")
+        var boxes = document.querySelectorAll(".box")
+        for (var i = 0; i < boxes.length; i++) {
+          var el = boxes[i]
+          el.onclick = function() {
+            log.textContent = this.id
+          }
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <div id="one" class="box"></div>
+    <div id="two" class="box"></div>
+    <div id="three" class="box"></div>
+    <div id="four" class="box"></div>
+    <div id="log"></div>
+    <svg id="svg" class="box"></svg>
+    <svg xmlns="http://www.w3.org/2000/svg" version="1.1">
+      <rect id="myrect" width="300" height="100" style="fill:rgb(0,0,255);stroke-width:1;stroke:rgb(0,0,0)" />
+    </svg>
+  </body>
 </html>

--- a/spec/support/views/computed_style.erb
+++ b/spec/support/views/computed_style.erb
@@ -1,6 +1,6 @@
 <style>
-.foo { color: red; }
-.bar { font-weight: bold; }
+  .foo { color: red; }
+  .bar { font-weight: bold; }
 </style>
 
 <span id="test_node" class="foo bar">Test</span>

--- a/spec/support/views/console_log.erb
+++ b/spec/support/views/console_log.erb
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <script type="text/javascript">
-  window.onload = function() {
-    console.log("Hello world");
-  }
-  </script>
-</head>
-<body>
-</body>
+  <head>
+    <script type="text/javascript">
+      window.onload = function() {
+        console.log("Hello world");
+      }
+    </script>
+  </head>
+  <body></body>
 </html>

--- a/spec/support/views/custom_html_size.erb
+++ b/spec/support/views/custom_html_size.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>custom_size</title>
@@ -8,6 +9,5 @@
       }
     </style>
   </head>
-  <body>
-  </body>
+  <body></body>
 </html>

--- a/spec/support/views/custom_html_size_100%.erb
+++ b/spec/support/views/custom_html_size_100%.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>custom_size</title>

--- a/spec/support/views/date_fields.erb
+++ b/spec/support/views/date_fields.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
   </head>

--- a/spec/support/views/datepicker.erb
+++ b/spec/support/views/datepicker.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>ferrum and datepicker</title>

--- a/spec/support/views/double_click_test.erb
+++ b/spec/support/views/double_click_test.erb
@@ -1,48 +1,48 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <style type="text/css">
-    body {
-      width: 800px;
-      margin: 0;
-    }
-    .box {
-      width: 200px;
-      height: 200px;
-      float: left;
-      margin: 100px;
-    }
-    #one {
-      background: red;
-    }
-    #two {
-      background: orange
-    }
-    #three {
-      background: blue;
-    }
-    #four {
-      background: green;
-    }
-  </style>
-  <script type="text/javascript">
-  window.onload = function() {
-    var log = document.querySelector("#log")
-    var boxes = document.querySelectorAll(".box")
-    for (var i = 0; i < boxes.length; i++) {
-      var el = boxes[i]
-      el.ondblclick = function() {
-        log.textContent = this.id
+  <head>
+    <style>
+      body {
+        width: 800px;
+        margin: 0;
       }
-    }
-  }
-  </script>
-</head>
-<body>
-  <div id="one" class="box"></div>
-  <div id="two" class="box"></div>
-  <div id="three" class="box"></div>
-  <div id="four" class="box"></div>
-  <div id="log"></div>
-</body>
+      .box {
+        width: 200px;
+        height: 200px;
+        float: left;
+        margin: 100px;
+      }
+      #one {
+        background: red;
+      }
+      #two {
+        background: orange
+      }
+      #three {
+        background: blue;
+      }
+      #four {
+        background: green;
+      }
+    </style>
+    <script type="text/javascript">
+      window.onload = function() {
+        var log = document.querySelector("#log")
+        var boxes = document.querySelectorAll(".box")
+        for (var i = 0; i < boxes.length; i++) {
+          var el = boxes[i]
+          el.ondblclick = function() {
+            log.textContent = this.id
+          }
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <div id="one" class="box"></div>
+    <div id="two" class="box"></div>
+    <div id="three" class="box"></div>
+    <div id="four" class="box"></div>
+    <div id="log"></div>
+  </body>
 </html>

--- a/spec/support/views/drag.erb
+++ b/spec/support/views/drag.erb
@@ -1,11 +1,12 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>ferrum drag_to and drag_by</title>
     <script src="/ferrum/jquery.min.js" type="text/javascript" charset="utf-8"></script>
     <script src="/ferrum/jquery-ui.min.js" type="text/javascript" charset="utf-8"></script>
 
-    <style type="text/css">
+    <style>
       #drag_by {
         position: relative;
         width: 200px;
@@ -22,28 +23,24 @@
     </style>
 
     <script>
-    $(function() {
-      $( ".draggable" ).draggable();
-      $( "#droppable" ).droppable({
-        drop: function( event, ui ) {
-          $( this )
-            .addClass( "dropped" )
-            .find( "p" )
-              .html( "Dropped!" );
-        }
+      $(function() {
+        $( ".draggable" ).draggable();
+        $( "#droppable" ).droppable({
+          drop: function( event, ui ) {
+            $( this )
+              .addClass( "dropped" )
+              .find( "p" )
+                .html( "Dropped!" );
+          }
+        });
       });
-    });
     </script>
   </head>
-
-
   <body>
-
     <div id="drag_to">
       <div id="draggable" class="draggable">
         <p>Drag me</p>
       </div>
-
       <div id="droppable">
         <p>Drop here</p>
       </div>
@@ -54,6 +51,5 @@
         <p>Drag me by</p>
       </div>
     </div>
-
   </body>
 </html>

--- a/spec/support/views/fieldsets.erb
+++ b/spec/support/views/fieldsets.erb
@@ -1,13 +1,10 @@
-
 <form action="/form" method="post">
   <fieldset id="agent_fieldset">
     <legend>Agent</legend>
-  
     <p>
       <label for="form_agent_name">Name</label>
       <input type="text" name="form[agent_name]" value="James" id="form_agent_name"/>
     </p>
-  
     <p>
       <input type="submit" value="Create"/>
     </p>
@@ -17,12 +14,10 @@
 <form action="/form" method="post">
   <fieldset id="villain_fieldset">
     <legend>Villain</legend>
-  
     <p>
       <label for="form_villain_name">Name</label>
       <input type="text" name="form[villain_name]" value="Ernst" id="form_villain_name"/>
     </p>
-  
     <p>
       <input type="submit" value="Create"/>
     </p>

--- a/spec/support/views/form.erb
+++ b/spec/support/views/form.erb
@@ -1,5 +1,4 @@
 <h1>Form</h1>
-
 <form action="/form" method="post" novalidate>
   <p>
     <label for="form_title">Title</label>
@@ -9,7 +8,7 @@
       <option>Miss</option>
       <option disabled="disabled">Other</option>
     </select>
-    </p>
+  </p>
 
   <p>
     <label for="customer_name">Customer Name

--- a/spec/support/views/form_iframe.erb
+++ b/spec/support/views/form_iframe.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <body>
     <select id="select">

--- a/spec/support/views/frame_child.erb
+++ b/spec/support/views/frame_child.erb
@@ -1,18 +1,18 @@
-
+<!DOCTYPE html>
 <html>
-    <head>
-        <title>This is the child frame title</title>
-        <script>
-        function closeWin() {
-          var iframe = window.parent.document.getElementById('childFrame');
-          iframe.parentNode.removeChild(iframe)
-        }
-        </script>
-    </head>
-    <body id="childBody">
-      <a href="javascript:void(0)" onClick="closeWin()">Close Window Now</a>
-      <a href="javascript:void(0)" onClick="setTimeout(function(){closeWin()}, 10)">Close Window Soon</a>
-      <iframe src="/frame_one" id="grandchildFrame1"></iframe>
-      <iframe src="/frame_two" id="grandchildFrame2"></iframe>
-    </body>
+  <head>
+    <title>This is the child frame title</title>
+    <script>
+      function closeWin() {
+        var iframe = window.parent.document.getElementById('childFrame');
+        iframe.parentNode.removeChild(iframe)
+      }
+    </script>
+  </head>
+  <body id="childBody">
+    <a href="javascript:void(0)" onClick="closeWin()">Close Window Now</a>
+    <a href="javascript:void(0)" onClick="setTimeout(function(){closeWin()}, 10)">Close Window Soon</a>
+    <iframe src="/frame_one" id="grandchildFrame1"></iframe>
+    <iframe src="/frame_two" id="grandchildFrame2"></iframe>
+  </body>
 </html>

--- a/spec/support/views/frame_one.erb
+++ b/spec/support/views/frame_one.erb
@@ -1,10 +1,10 @@
-
+<!DOCTYPE html>
 <html>
-    <head>
-        <title>This is the title of frame one</title>
-    </head>
-    <body>
-        <div id="divInFrameOne">This is the text of divInFrameOne</div>
-        <div id="otherDivInFrameOne">Some other text</div>
-    </body>
+  <head>
+    <title>This is the title of frame one</title>
+  </head>
+  <body>
+    <div id="divInFrameOne">This is the text of divInFrameOne</div>
+    <div id="otherDivInFrameOne">Some other text</div>
+  </body>
 </html>

--- a/spec/support/views/frame_parent.erb
+++ b/spec/support/views/frame_parent.erb
@@ -1,9 +1,9 @@
-
+<!DOCTYPE html>
 <html>
-    <head>
-        <title>This is the parent frame title</title>
-    </head>
-    <body id="parentBody">
-      <iframe src='/frame_child' id='childFrame'></iframe>
-    </body>
+  <head>
+    <title>This is the parent frame title</title>
+  </head>
+  <body id="parentBody">
+    <iframe src='/ferrum/frame_child' id='childFrame'></iframe>
+  </body>
 </html>

--- a/spec/support/views/frame_two.erb
+++ b/spec/support/views/frame_two.erb
@@ -1,9 +1,9 @@
-
+<!DOCTYPE html>
 <html>
-    <head>
-        <title>This is the title of frame two</title>
-    </head>
-    <body>
-        <div id="divInFrameTwo">This is the text of divInFrameTwo</div>
-    </body>
+  <head>
+    <title>This is the title of frame two</title>
+  </head>
+  <body>
+    <div id="divInFrameTwo">This is the text of divInFrameTwo</div>
+  </body>
 </html>

--- a/spec/support/views/frames.erb
+++ b/spec/support/views/frames.erb
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
-<body>
-<iframe name="frame"></iframe>
-<iframe></iframe>
-<iframe id="id_frame"></iframe>
-</body>
-<script type="text/javascript">
-document.getElementsByName("frame")[0].src = "http://localhost:" + location.port + "/ferrum/slow";
-document.querySelector("iframe:not([name]):not([id])").src = "http://localhost:" + location.port + "/ferrum/headers";
-document.querySelector("#id_frame").src = "http://localhost:" + location.port + "/ferrum/get_cookie";
-</script>
+  <body>
+    <iframe name="frame"></iframe>
+    <iframe></iframe>
+    <iframe id="id_frame"></iframe>
+  </body>
+  <script type="text/javascript">
+    document.getElementsByName("frame")[0].src = "http://localhost:" + location.port + "/ferrum/slow";
+    document.querySelector("iframe:not([name]):not([id])").src = "http://localhost:" + location.port + "/ferrum/headers";
+    document.querySelector("#id_frame").src = "http://localhost:" + location.port + "/ferrum/get_cookie";
+  </script>
 </html>

--- a/spec/support/views/grid.erb
+++ b/spec/support/views/grid.erb
@@ -28,7 +28,6 @@
 </script>
 
 <style>
-
   body {
     margin: 0;
     padding: 0;

--- a/spec/support/views/header_links.erb
+++ b/spec/support/views/header_links.erb
@@ -1,4 +1,3 @@
-
 <p>
   <a href="/get_header">Link</a>
 </p>

--- a/spec/support/views/headers_with_ajax.erb
+++ b/spec/support/views/headers_with_ajax.erb
@@ -1,25 +1,25 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <script type="text/javascript">
-    window.onload = function() {
-      var request = new XMLHttpRequest();
-      request.open("GET", "/ferrum/headers", false);
-      request.send();
+  <head>
+    <script type="text/javascript">
+      window.onload = function() {
+        var request = new XMLHttpRequest();
+        request.open("GET", "/ferrum/headers", false);
+        request.send();
 
-      if (request.status === 200) {
-        var div = document.getElementById("ajax_request");
-        div.innerHTML = request.responseText;
+        if (request.status === 200) {
+          var div = document.getElementById("ajax_request");
+          div.innerHTML = request.responseText;
+        }
       }
-    }
-  </script>
-</head>
-<body>
-  <div id="initial_request">
-    <% for header in request.env.select {|k,v| k.match("^HTTP.*")} %>
-      <%=header[0].split("_",2)[1]%>: <%=header[1]%>
-    <% end %>
-  </div>
-  <div id="ajax_request"></div>
-</body>
+    </script>
+  </head>
+  <body>
+    <div id="initial_request">
+      <% for header in request.env.select {|k,v| k.match("^HTTP.*")} %>
+        <%=header[0].split("_",2)[1]%>: <%=header[1]%>
+      <% end %>
+    </div>
+    <div id="ajax_request"></div>
+  </body>
 </html>

--- a/spec/support/views/host_links.erb
+++ b/spec/support/views/host_links.erb
@@ -1,4 +1,3 @@
-
 <p>
   <a href="/host">Relative Host</a>
   <a href="<%= params[:absolute_host] %>/host">Absolute Host</a>

--- a/spec/support/views/image_map.erb
+++ b/spec/support/views/image_map.erb
@@ -1,32 +1,32 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <style type="text/css">
-    img {
-      display: block;
-      height: 100px;
-      width: 100px;
-    }
-  </style>
-  <script>
-    function log_msg(msg) {
-      document.getElementById("log").textContent = msg;
-    }
-  </script>
-</head>
-<body>
-  <img usemap="#testmap" src="data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA="/>
-  <map name="testmap">
-    <area shape="rect" coords="10,10,55,55" href="#" onclick="log_msg('rect clicked')">
-    <area shape="circle" coords="70,70,10" href="#" onclick="log_msg('circle clicked')">
-  </map>
+  <head>
+    <style type="text/css">
+      img {
+        display: block;
+        height: 100px;
+        width: 100px;
+      }
+    </style>
+    <script>
+      function log_msg(msg) {
+        document.getElementById("log").textContent = msg;
+      }
+    </script>
+  </head>
+  <body>
+    <img usemap="#testmap" src="data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA="/>
+    <map name="testmap">
+      <area shape="rect" coords="10,10,55,55" href="#" onclick="log_msg('rect clicked')">
+      <area shape="circle" coords="70,70,10" href="#" onclick="log_msg('circle clicked')">
+    </map>
 
-  <img usemap="#testmap2" style="display: none;" src="data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA="/>
-  <map name="testmap2">
-    <area shape="rect" coords="10,10,55,55" href="#" onclick="log_msg('rect2 clicked')">
-    <area shape="circle" coords="70,70,10" href="#" onclick="log_msg('circle2 clicked')">
-  </map>
-  <div id="log">
-  </div>
-</body>
+    <img usemap="#testmap2" style="display: none;" src="data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA="/>
+    <map name="testmap2">
+      <area shape="rect" coords="10,10,55,55" href="#" onclick="log_msg('rect2 clicked')">
+      <area shape="circle" coords="70,70,10" href="#" onclick="log_msg('circle2 clicked')">
+    </map>
+    <div id="log">
+    </div>
+  </body>
 </html>

--- a/spec/support/views/initial_alert.erb
+++ b/spec/support/views/initial_alert.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <body>
     <div>
       Initial alert page

--- a/spec/support/views/input_events.erb
+++ b/spec/support/views/input_events.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <body>
     <input id="input" type="text">
     <div id="output"></div>

--- a/spec/support/views/nested_frame_test.erb
+++ b/spec/support/views/nested_frame_test.erb
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <style type="text/css">
-    body {
-      background: yellow;
-    }
-  </style>
-</head>
-<body>
-  <iframe src="/ferrum/click_test" name="inner_frame"></iframe>
-</body>
+  <head>
+    <style type="text/css">
+      body {
+        background: yellow;
+      }
+    </style>
+  </head>
+  <body>
+    <iframe src="/ferrum/click_test" name="inner_frame"></iframe>
+  </body>
 </html>

--- a/spec/support/views/obscured.erb
+++ b/spec/support/views/obscured.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>

--- a/spec/support/views/offset.erb
+++ b/spec/support/views/offset.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
@@ -29,4 +30,4 @@
       <div id="clicker"></div>
     </div>
   </body>
-  </html>
+</html>

--- a/spec/support/views/orig_scroll.erb
+++ b/spec/support/views/orig_scroll.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html style="height: 250%; width: 150%">
   <head>
     <style>
@@ -15,6 +16,5 @@
         <div id="inner">inner</div>
       </div>
     </div>
-  </div>
   </body>
 </html>

--- a/spec/support/views/orig_with_js.erb
+++ b/spec/support/views/orig_with_js.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>with_js</title>
@@ -6,7 +7,6 @@
     <script src="/ferrum/jquery-ui.min.js" type="text/javascript" charset="utf-8"></script>
     <script src="/test.js" type="text/javascript" charset="utf-8"></script>
   </head>
-
   <body id="with_js">
     <h1>FooBar</h1>
 

--- a/spec/support/views/path.erb
+++ b/spec/support/views/path.erb
@@ -1,5 +1,5 @@
-
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <body>
     <div>
       <a href="#">First Link</a>

--- a/spec/support/views/popup_one.erb
+++ b/spec/support/views/popup_one.erb
@@ -1,9 +1,9 @@
-
+<!DOCTYPE html>
 <html>
-    <head>
-        <title>Title of the first popup</title>
-    </head>
-    <body>
-        <div id="divInPopupOne">This is the text of divInPopupOne</div>
-    </body>
+  <head>
+    <title>Title of the first popup</title>
+  </head>
+  <body>
+    <div id="divInPopupOne">This is the text of divInPopupOne</div>
+  </body>
 </html>

--- a/spec/support/views/popup_two.erb
+++ b/spec/support/views/popup_two.erb
@@ -1,4 +1,4 @@
-
+<!DOCTYPE html>
 <html>
     <head>
         <title>Title of popup two</title>

--- a/spec/support/views/postback.erb
+++ b/spec/support/views/postback.erb
@@ -1,4 +1,3 @@
-
 <h1>Postback</h1>
 
 <form method="get">

--- a/spec/support/views/react.erb
+++ b/spec/support/views/react.erb
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <script src="https://unpkg.com/react/umd/react.development.js"></script>

--- a/spec/support/views/requiring_custom_extension.erb
+++ b/spec/support/views/requiring_custom_extension.erb
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <html>
-<head>
-</head>
-<body>
-  <p>Location: <span id="location"></span></p>
+  <head></head>
+  <body>
+    <p>Location: <span id="location"></span></p>
 
-  <script type="text/javascript">
-    navigator.geolocation.getCurrentPosition(function(position) {
-      document.getElementById("location").innerHTML = position.coords.latitude + "," + position.coords.longitude;
-    });
-  </script>
-</body>
+    <script type="text/javascript">
+      navigator.geolocation.getCurrentPosition(function(position) {
+        document.getElementById("location").innerHTML = position.coords.latitude + "," + position.coords.longitude;
+      });
+    </script>
+  </body>
 </html>

--- a/spec/support/views/scroll.erb
+++ b/spec/support/views/scroll.erb
@@ -3,13 +3,11 @@
   <head>
     <title>scroll</title>
   </head>
-
   <body>
     <div style="height: 100px; overflow-y: auto">
       <div style="height: 300px;">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin lacus odio, dapibus id bibendum in, rhoncus sed dolor. In quis nulla at diam euismod suscipit vitae vitae sapien. Nam viverra hendrerit augue a accumsan. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Fusce fermentum tortor at neque malesuada sodales. Nunc quis augue a quam venenatis pharetra sit amet et risus. Nulla pharetra enim a leo varius scelerisque aliquam urna vestibulum. Sed felis eros, iaculis convallis fermentum ac, condimentum ac lacus. Sed turpis magna, tristique eu faucibus non, faucibus vitae elit. Morbi venenatis adipiscing aliquam.</p>
       </div>
-
       <p>
         <a href="/">Link outside viewport</a>
       </p>

--- a/spec/support/views/set.erb
+++ b/spec/support/views/set.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
   </head>

--- a/spec/support/views/tables.erb
+++ b/spec/support/views/tables.erb
@@ -1,4 +1,3 @@
-
 <form action="/form" method="post">
   <table id="agent_table">
     <caption>Agent</caption>

--- a/spec/support/views/type.erb
+++ b/spec/support/views/type.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
   </head>

--- a/spec/support/views/visible.erb
+++ b/spec/support/views/visible.erb
@@ -3,7 +3,6 @@
   <head>
     <title>Test</title>
   </head>
-
   <body>
     <ul>
       <li>Visible</li>

--- a/spec/support/views/with_animation.erb
+++ b/spec/support/views/with_animation.erb
@@ -1,5 +1,5 @@
-
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>with_animation</title>
@@ -44,8 +44,8 @@
       }
 
       @keyframes animation {
-          0%   {height: 20px; width: 100%;}
-          100% {height: 0px; width: 0%;}
+          0%   { height: 20px; width: 100%; }
+          100% { height: 0px; width: 0%; }
       }
 
       a.animation.away {
@@ -55,7 +55,7 @@
       }
 
       @keyframes pseudo_grow {
-        100% { height: 100px, width: 100px };
+        100% { height: 100px; width: 100px; }
       }
 
       a.animation.pseudo::after {
@@ -71,4 +71,3 @@
     </a>
   </body>
 </html>
-

--- a/spec/support/views/with_base_tag.erb
+++ b/spec/support/views/with_base_tag.erb
@@ -1,5 +1,5 @@
-
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <base href="http://example2.com" />
@@ -8,4 +8,4 @@
   <body id="with_js">
     <h1>FooBar</h1>
   </body>
-</html
+</html>

--- a/spec/support/views/with_count.erb
+++ b/spec/support/views/with_count.erb
@@ -1,4 +1,3 @@
-
 <h1>This page is used for testing number options of has_text?</h1>
 
 <p>count1</p>

--- a/spec/support/views/with_different_resources.erb
+++ b/spec/support/views/with_different_resources.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>ferrum with_different_resources</title>

--- a/spec/support/views/with_dragula.erb
+++ b/spec/support/views/with_dragula.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>with_dragula</title>

--- a/spec/support/views/with_fixed_header_footer.erb
+++ b/spec/support/views/with_fixed_header_footer.erb
@@ -1,17 +1,19 @@
+<!DOCTYPE html>
 <html>
-<head>
-  <style>
-    header { height: 45px; position: fixed; top: 0; background-color: red; width: 100%;}
-    footer { height: 45px; position: fixed; bottom: 0; background-color: red; width: 100%;}
-    #main { margin: 45px;}
-    #tall { display: block; height: 2000px;}
-  </style>
-</head>
-<body>
-  <header>My headers</header>
-    <div id="main">
-      <div id="tall">A tall block</div>
-      <a href="/">Go to root</a>
-    </div>
-  <footer>My footer</footer>
-</body>
+  <head>
+    <style>
+      header { height: 45px; position: fixed; top: 0; background-color: red; width: 100%;}
+      footer { height: 45px; position: fixed; bottom: 0; background-color: red; width: 100%;}
+      #main { margin: 45px;}
+      #tall { display: block; height: 2000px;}
+    </style>
+  </head>
+  <body>
+    <header>My headers</header>
+      <div id="main">
+        <div id="tall">A tall block</div>
+        <a href="/">Go to root</a>
+      </div>
+    <footer>My footer</footer>
+  </body>
+</html>

--- a/spec/support/views/with_hover.erb
+++ b/spec/support/views/with_hover.erb
@@ -1,5 +1,4 @@
-
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>with_hover</title>

--- a/spec/support/views/with_hover1.erb
+++ b/spec/support/views/with_hover1.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
   </head>

--- a/spec/support/views/with_html.erb
+++ b/spec/support/views/with_html.erb
@@ -1,4 +1,3 @@
-
 <style>
   p { display: block; }
 </style>

--- a/spec/support/views/with_html5_svg.erb
+++ b/spec/support/views/with_html5_svg.erb
@@ -15,6 +15,6 @@
         <rect x="150" y="150" width="25" height="25" style="fill:url(#gradient)" />
         <circle cx="50" cy="50" r="30" style="fill:url(#gradient)" />
       </svg>
-    <div>
+    </div>
   </body>
 </html>

--- a/spec/support/views/with_js.erb
+++ b/spec/support/views/with_js.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>ferrum with_js</title>

--- a/spec/support/views/with_jstree.erb
+++ b/spec/support/views/with_jstree.erb
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>

--- a/spec/support/views/with_namespace.erb
+++ b/spec/support/views/with_namespace.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
   <head>
     <title>Namespace</title>
   </head>
@@ -15,6 +16,6 @@
         <rect x="150" y="150" width="25" height="25" style="fill:url(#gradient)" />
         <circle cx="50" cy="50" r="30" style="fill:url(#gradient)" />
       </svg>
-    <div>
+    </div>
   </body>
 </html>

--- a/spec/support/views/with_scope.erb
+++ b/spec/support/views/with_scope.erb
@@ -1,4 +1,3 @@
-
 <h1>This page is used for testing various scopes</h1>
 
 <p id="for_foo">

--- a/spec/support/views/with_scope_other.erb
+++ b/spec/support/views/with_scope_other.erb
@@ -1,4 +1,3 @@
-
 <h1>This page is used for testing various scopes</h1>
 
 <p id="for_foo">

--- a/spec/support/views/with_slow_unload.erb
+++ b/spec/support/views/with_slow_unload.erb
@@ -1,17 +1,18 @@
+<!DOCTYPE html>
 <html>
-<head>
-  <script>
-    function delay_unload() {
-      var start = new Date();
-      var i = 0;
-      while ((new Date()) - start < 1000){ i = i + 1; };
-      return null;
-    }
-    window.onbeforeunload = delay_unload;
-    window.onunload = delay_unload;
-  </script>
-</head>
-<body>
-  <div>This delays unload by 2 seconds</div>
-</body>
+  <head>
+    <script>
+      function delay_unload() {
+        var start = new Date();
+        var i = 0;
+        while ((new Date()) - start < 1000){ i = i + 1; };
+        return null;
+      }
+      window.onbeforeunload = delay_unload;
+      window.onunload = delay_unload;
+    </script>
+  </head>
+  <body>
+    <div>This delays unload by 2 seconds</div>
+  </body>
 </html>

--- a/spec/support/views/with_sortable_js.erb
+++ b/spec/support/views/with_sortable_js.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>with_sortable_js</title>

--- a/spec/support/views/with_title.erb
+++ b/spec/support/views/with_title.erb
@@ -1,4 +1,3 @@
-
 <title>Test Title</title>
 <body>
   <svg><title>abcdefg</title></svg>

--- a/spec/support/views/with_unload_alert.erb
+++ b/spec/support/views/with_unload_alert.erb
@@ -1,14 +1,15 @@
+<!DOCTYPE html>
 <html>
-<head>
-  <script>
-      window.onbeforeunload = function(e) {
-        return 'Unload?';
-      };
-  </script>
-</head>
-<body>
-  <div>This triggers an alert on unload</div>
+  <head>
+    <script>
+        window.onbeforeunload = function(e) {
+          return 'Unload?';
+        };
+    </script>
+  </head>
+  <body>
+    <div>This triggers an alert on unload</div>
 
-  <a href="/">Go away</a>
-</body>
+    <a href="/">Go away</a>
+  </body>
 </html>

--- a/spec/support/views/with_user_js.erb
+++ b/spec/support/views/with_user_js.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>ferrum with_user_js</title>

--- a/spec/support/views/with_windows.erb
+++ b/spec/support/views/with_windows.erb
@@ -1,4 +1,4 @@
-
+<!DOCTYPE html>
 <html>
   <head>
     <title>With Windows</title>

--- a/spec/support/views/within_frames.erb
+++ b/spec/support/views/within_frames.erb
@@ -1,15 +1,15 @@
-
+<!DOCTYPE html>
 <html>
-    <head>
-        <title>With Frames</title>
-    </head>
-    <body>
-        <div id="divInMainWindow">
-          This is the text for divInMainWindow
-          <iframe src="/frame_parent" id="innerParentFrame"></iframe>
-        </div>
-    <iframe src="/frame_one" id="frameOne" name="my frame one"></iframe>
-    <iframe src="/frame_two" id="frameTwo"></iframe>
-    <iframe src="/frame_parent" id="parentFrame"></iframe>
-    </body>
+  <head>
+    <title>With Frames</title>
+  </head>
+  <body>
+    <div id="divInMainWindow">
+      This is the text for divInMainWindow
+      <iframe src="/frame_parent" id="innerParentFrame"></iframe>
+    </div>
+  <iframe src="/frame_one" id="frameOne" name="my frame one"></iframe>
+  <iframe src="/frame_two" id="frameTwo"></iframe>
+  <iframe src="/frame_parent" id="parentFrame"></iframe>
+  </body>
 </html>


### PR DESCRIPTION
part of fac/dev-platform#1294

Branches from `main` @ 797558dbda4fee6145e411d4d16364cd696cb7e3,
not from tag `v0.13.0` @ 6dcc82f93a9f52ed3318c48ca1fa106bf7733c3d

# What
Adds additional logging around:
- spawning the chrome process
- detecting the websocket
- ps output for the running process (to demonstrate that we have a consecutive browser instance)
- closing the browser process

All of this logging ends up in the logger, in our case capybara(_mobile).log

<details>
<summary>Example log</summary>

```
Attemping to spawn chrome with:
  env: {}
  command: /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --headless --disable-gpu --hide-scrollbars --mute-audio --enable-automation --disable-web-security --disable-session-crashed-bubble --disable-breakpad --disable-sync --no-first-run --use-mock-keychain --keep-alive-for-test --disable-popup-blocking --disable-extensions --disable-hang-monitor --disable-features=site-per-process,TranslateUI --disable-translate --disable-background-networking --enable-features=NetworkService,NetworkServiceInProcess --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-client-side-phishing-detection --disable-default-apps --disable-dev-shm-usage --disable-ipc-flooding-protection --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --safebrowsing-disable-auto-update --password-store=basic --no-startup-window --remote-debugging-port=0 --remote-debugging-address=127.0.0.1 --window-size=1280,2000 --user-data-dir=/var/folders/7l/fxzbw4vd5tl5910l52r9rgth0000gp/T/ferrum_user_data_dir_20221129-73536-k6cmlo --force-prefers-reduced-motion --no-sandbox --enable-logging --v=1 --log-level=0
  process options: {:in=>"/dev/null", :pgroup=>true, :err=>#<IO:fd 21>, :out=>#<IO:fd 21>}

spawned chrome (73805):
  PID   TT  STAT      TIME COMMAND
73805 s002  U      0:00.06 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --headless --disable-gpu --hide-scrollbars --mute-audio --enable-automation --disable-web-security --disable-session-crashed-bubble --disable-breakpad --disable-sync --no-first-run --use-mock-keychain --keep-alive-for-test --disable-popup-blocking --disable-extensions --disable-hang-monitor --disable-features=site-per-process,TranslateUI --disable-translate --disable-background-networking --enable-features=NetworkService,NetworkServiceInProcess --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-client-side-phishing-detection --disable-default-apps --disable-dev-shm-usage --disable-ipc-flooding-protection --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --safebrowsing-disable-auto-update --password-store=basic --no-startup-window --remote-debugging-port=0 --remote-debugging-address=127.0.0.1 --window-size=1280,2000 --user-data-dir=/var/folders/7l/fxzbw4vd5tl5910l52r9rgth0000gp/T/ferrum_user_data_dir_20221129-73536-k6cmlo --force-prefers-reduced-motion --no-sandbox --enable-logging --v=1 --log-level=0
Attemping to detect websocket for chrome (73805)
Listening for websocket loop: 1 [114539.333557]
chrome (73805):
   PID   TT  STAT      TIME COMMAND
73805 s002  S      0:00.07 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --headless --disable-gpu --hide-scrollbars --mute-audio --enable-automation --disable-web-security --disable-session-crashed-bubble --disable-breakpad --disable-sync --no-first-run --use-mock-keychain --keep-alive-for-test --disable-popup-blocking --disable-extensions --disable-hang-monitor --disable-features=site-per-process,TranslateUI --disable-translate --disable-background-networking --enable-features=NetworkService,NetworkServiceInProcess --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-client-side-phishing-detection --disable-default-apps --disable-dev-shm-usage --disable-ipc-flooding-protection --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --safebrowsing-disable-auto-update --password-store=basic --no-startup-window --remote-debugging-port=0 --remote-debugging-address=127.0.0.1 --window-size=1280,2000 --user-data-dir=/var/folders/7l/fxzbw4vd5tl5910l52r9rgth0000gp/T/ferrum_user_data_dir_20221129-73536-k6cmlo --force-prefers-reduced-motion --no-sandbox --enable-logging --v=1 --log-level=0

No new IO stream output from chrome (73805). Retrying ...
Listening for websocket loop: 2 [114539.473341]
chrome (73805):
   PID   TT  STAT      TIME COMMAND
73805 s002  S      0:00.11 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --headless --disable-gpu --hide-scrollbars --mute-audio --enable-automation --disable-web-security --disable-session-crashed-bubble --disable-breakpad --disable-sync --no-first-run --use-mock-keychain --keep-alive-for-test --disable-popup-blocking --disable-extensions --disable-hang-monitor --disable-features=site-per-process,TranslateUI --disable-translate --disable-background-networking --enable-features=NetworkService,NetworkServiceInProcess --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-client-side-phishing-detection --disable-default-apps --disable-dev-shm-usage --disable-ipc-flooding-protection --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --safebrowsing-disable-auto-update --password-store=basic --no-startup-window --remote-debugging-port=0 --remote-debugging-address=127.0.0.1 --window-size=1280,2000 --user-data-dir=/var/folders/7l/fxzbw4vd5tl5910l52r9rgth0000gp/T/ferrum_user_data_dir_20221129-73536-k6cmlo --force-prefers-reduced-motion --no-sandbox --enable-logging --v=1 --log-level=0

chrome (73805) IO stream output:
[1129/165003.525545:VERBOSE1:webrtc_internals.cc(120)] Could not get the download directory.
[1129/165003.526099:VERBOSE1:media_stream_manager.cc(1079)] MSM::InitializeMaybeAsync([this=0x12c004e4800])
[1129/165003.526154:VERBOSE1:media_stream_manager.cc(1079)] MDM::MediaDevicesManager()
[1129/165003.526185:VERBOSE1:media_stream_manager.cc(1079)] MSM::MediaStreamManager([this=0x12c004e4800]))

***
Listening for websocket loop: 3 [114539.560844]
chrome (73805):
   PID   TT  STAT      TIME COMMAND
73805 s002  S      0:00.11 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --headless --disable-gpu --hide-scrollbars --mute-audio --enable-automation --disable-web-security --disable-session-crashed-bubble --disable-breakpad --disable-sync --no-first-run --use-mock-keychain --keep-alive-for-test --disable-popup-blocking --disable-extensions --disable-hang-monitor --disable-features=site-per-process,TranslateUI --disable-translate --disable-background-networking --enable-features=NetworkService,NetworkServiceInProcess --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-client-side-phishing-detection --disable-default-apps --disable-dev-shm-usage --disable-ipc-flooding-protection --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --safebrowsing-disable-auto-update --password-store=basic --no-startup-window --remote-debugging-port=0 --remote-debugging-address=127.0.0.1 --window-size=1280,2000 --user-data-dir=/var/folders/7l/fxzbw4vd5tl5910l52r9rgth0000gp/T/ferrum_user_data_dir_20221129-73536-k6cmlo --force-prefers-reduced-motion --no-sandbox --enable-logging --v=1 --log-level=0

No new IO stream output from chrome (73805). Retrying ...
Listening for websocket loop: 4 [114539.711713]
chrome (73805):
   PID   TT  STAT      TIME COMMAND
73805 s002  R      0:00.15 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --headless --disable-gpu --hide-scrollbars --mute-audio --enable-automation --disable-web-security --disable-session-crashed-bubble --disable-breakpad --disable-sync --no-first-run --use-mock-keychain --keep-alive-for-test --disable-popup-blocking --disable-extensions --disable-hang-monitor --disable-features=site-per-process,TranslateUI --disable-translate --disable-background-networking --enable-features=NetworkService,NetworkServiceInProcess --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-client-side-phishing-detection --disable-default-apps --disable-dev-shm-usage --disable-ipc-flooding-protection --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --safebrowsing-disable-auto-update --password-store=basic --no-startup-window --remote-debugging-port=0 --remote-debugging-address=127.0.0.1 --window-size=1280,2000 --user-data-dir=/var/folders/7l/fxzbw4vd5tl5910l52r9rgth0000gp/T/ferrum_user_data_dir_20221129-73536-k6cmlo --force-prefers-reduced-motion --no-sandbox --enable-logging --v=1 --log-level=0

chrome (73805) IO stream output:
[1129/165003.525545:VERBOSE1:webrtc_internals.cc(120)] Could not get the download directory.
[1129/165003.526099:VERBOSE1:media_stream_manager.cc(1079)] MSM::InitializeMaybeAsync([this=0x12c004e4800])
[1129/165003.526154:VERBOSE1:media_stream_manager.cc(1079)] MDM::MediaDevicesManager()
[1129/165003.526185:VERBOSE1:media_stream_manager.cc(1079)] MSM::MediaStreamManager([this=0x12c004e4800]))

DevTools listening on ws://127.0.0.1:49652/devtools/browser/655a121f-304a-46cf-b8ad-6ed30db17049
[1129/165003.795703:VERBOSE1:first_party_sets_handler_impl.cc(406)] Empty path. Failed initializing First-Party Sets database.
[1129/165003.890781:WARNING:address_sorter_posix.cc(395)] FromSockAddr failed on netmask

***

websocket detected for chrome (73805): ws://127.0.0.1:49652/devtools/browser/655a121f-304a-46cf-b8ad-6ed30db17049
Chrome (73805) is ready

▶ 0.7620900000038091 {"method":"Target.setDiscoverTargets","params":{"discover":true},"id":1}
    ◀ 0.7784570000076201 {"method":"Target.targetCreated","params":{"targetInfo":{"targetId":"A56CA59FBE750355D5663B3837EE202A","type":"page","title":"","url":"about:blank","attached":false,"canAccessOpener":false,"browserContextId":"7CB43521AC88004FFE2EFF067F8D622F"}}}
    ◀ 0.7785260000091512 {"id":1,"result":{}}
    ◀ 0.7815879999980098 {"id":2,"result":{"browserContextId":"93F8B497B7E88EEC2D2DD48E089C11A6"}}

[...]
Attemping to kill chrome (73805)
Waiting for chrome (73805) to end
```
</details>