### PR TITLE
Adding logging around pending errors (tag v0.13.0)

### DIFF
--- a/lib/ferrum/network.rb
+++ b/lib/ferrum/network.rb
@@ -59,12 +59,18 @@ module Ferrum
     #   browser.network.wait_for_idle
     #
     def wait_for_idle(connections: 0, duration: 0.05, timeout: @page.browser.timeout)
+      puts "Ferrum: wait_for_idle: connections: #{connections} duration: #{duration} timeout: #{timeout}"
       start = Utils::ElapsedTime.monotonic_time
 
-      until idle?(connections)
-        raise TimeoutError if Utils::ElapsedTime.timeout?(start, timeout)
+      begin
+        until idle?(connections)
+          raise TimeoutError if Utils::ElapsedTime.timeout?(start, timeout)
 
-        sleep(duration)
+          sleep(duration)
+        end
+      rescue TimeoutError
+        @traffic.each{ |r| pp r if r.pending?};
+        raise TimeoutError
       end
     end
 


### PR DESCRIPTION
Branched from tag v0.13.0:
Doesn't include latest 4 changes, specifically doesn't include: https://github.com/fac/ferrum/commit/81ab27a4ec7da6ee4e9b17130a9fae1bb5233381
which changes how `finished?` resolves, breaking on redirect, `302` requests.