### PR TITLE
Add pending logging

### DIFF
--- a/lib/ferrum/browser/client.rb
+++ b/lib/ferrum/browser/client.rb
@@ -43,7 +43,7 @@ module Ferrum
         @pendings.delete(message[:id])
 
         raise DeadBrowserError if data.nil? && @ws.messages.closed?
-        raise TimeoutError unless data
+        raise TimeoutError.new() unless data
 
         error, response = data.values_at("error", "result")
         raise_browser_error(error) if error

--- a/lib/ferrum/errors.rb
+++ b/lib/ferrum/errors.rb
@@ -27,11 +27,17 @@ module Ferrum
   end
 
   class TimeoutError < Error
-    def message
-      "Timed out waiting for response. It's possible that this happened " \
-        "because something took a very long time (for example a page load " \
-        "was slow). If so, setting the :timeout option to a higher value might " \
-        "help."
+    attr_reader :pending_urls
+
+    def initialize(pending_urls = [])
+      @pending_urls = pending_urls
+
+      message = "Timed out waiting for response. It's possible that this happened " \
+                "because something took a very long time (for example a page load " \
+                "was slow). If so, setting the :timeout option to a higher value might " \
+                "help."
+      message = "#{message}\n Connections still pending:\n #{pending_urls.join(', ')}" unless pending_urls.empty?
+      super(message)
     end
   end
 

--- a/lib/ferrum/network.rb
+++ b/lib/ferrum/network.rb
@@ -62,7 +62,13 @@ module Ferrum
       start = Utils::ElapsedTime.monotonic_time
 
       until idle?(connections)
-        raise TimeoutError if Utils::ElapsedTime.timeout?(start, timeout)
+        if Utils::ElapsedTime.timeout?(start, timeout)
+          if @page.browser.options.pending_connection_errors
+            pendings = traffic.select(&:pending?)
+            pending_urls = pendings.map(&:url).compact
+          end
+          raise TimeoutError.new(pending_urls = pending_urls)
+        end
 
         sleep(duration)
       end

--- a/lib/ferrum/network.rb
+++ b/lib/ferrum/network.rb
@@ -66,6 +66,7 @@ module Ferrum
           if @page.browser.options.pending_connection_errors
             pendings = traffic.select(&:pending?)
             pending_urls = pendings.map(&:url).compact
+            puts("[DEBUG] 'wait_for_idle' pending connections:\n#{pendings.map(&:inspect)}")
           end
           raise TimeoutError.new(pending_urls = pending_urls)
         end

--- a/lib/ferrum/page.rb
+++ b/lib/ferrum/page.rb
@@ -282,7 +282,7 @@ module Ferrum
         @event.wait(wait)
         if iteration != @event.iteration
           set = @event.wait(timeout)
-          raise TimeoutError unless set
+          raise TimeoutError.new() unless set
         end
       end
       result


### PR DESCRIPTION
# What
After reverting this fork back to the upstream `0.13.0` tag, we want to explicitly emit pending connections when we raise a `TimeoutError` from `wait_for_idle`.
There are three places that `TimeoutError` gets raised, each has it's own context, and so will need custom error handling if we want to get specific useful information out:

```
./lib/ferrum/page.rb
285:          raise TimeoutError.new() unless set

./lib/ferrum/browser/client.rb
46:        raise TimeoutError.new() unless data

./lib/ferrum/network.rb
71:          raise TimeoutError.new(pending_urls = pending_urls)
```

# How
Deliberately triggering a failure in a spec:
```
wait_for_network_idle(connections:-1, timeout: 0)
```
Example output:
```
Failures:

  1) Bills UK Limited Company allows the user to create a new foreign currency bill
     Failure/Error: page.driver.wait_for_network_idle(**options)
     
     Ferrum::TimeoutError:
       Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
        Connections still pending:
        http://subdomain000001.lvh.me:9887/bills/inline_bill_item
     # /Users/dalemorgan/dev/ferrum/lib/ferrum/network.rb:71:in `wait_for_idle'
     # /Users/dalemorgan/.gem/ruby/3.1.3/bundler/gems/cuprite-2fe6236fe66e/lib/capybara/cuprite/driver.rb:262:in `wait_for_network_idle'
     # ./spec/support/helpers/feature_spec_helper.rb:212:in `wait_for_network_idle'
     # ./spec/features/bills/create_spec.rb:125:in `block (3 levels) in <top (required)>'
     # ./spec/support/capybara.rb:59:in `block (2 levels) in <main>'
     # ./spec/support/example_index.rb:22:in `block (2 levels) in <main>'
     # ./engines/radar_todos/spec/support/helper.rb:28:in `block (2 levels) in <main>'

Finished in 8.59 seconds (files took 11.77 seconds to load)
1 example, 1 failure
```

<details>
<summary>We're also dumping as much of the pending context as possible:</summary>

```
rsp spec/features/bills/create_spec.rb:122
WARNING: `sqreen` gem not installed, using a class stub instead.
Run options:
  include {:locations=>{"./spec/features/bills/create_spec.rb"=>[122]}}
  exclude {:"known-failure"=>true, :factorybot_lint=>true, :visual_regression=>true}

Bills
  UK Limited Company
Capybara starting Puma...
* Version 6.0.0 , codename: Sunflower
* Min threads: 0, max threads: 4
* Listening on http://0.0.0.0:9887
[DEBUG] 'wait_for_idle' pending connections:
["#<Ferrum::Network::Exchange @id=\"59581.66\" @intercepted_request=#<Ferrum::Network::InterceptedRequest @request_id=\"interception-job-34.0\" @frame_id=\"64B7201DA2424E9FD64676000455BE78\" @resource_type=\"XHR\" @request={\"url\"=>\"http://subdomain000001.lvh.me:9887/bills/inline_bill_item\", \"method\"=>\"POST\", \"headers\"=>{\"Accept\"=>\"text/vnd.turbo-stream.html, text/html\", \"Content-Type\"=>\"multipart/form-data; boundary=----WebKitFormBoundary2bjByxPLNhwS1B29\", \"Cookie\"=>\"fa_user_session_key=eyJfcmFpbHMiOnsibWVzc2FnZSI6IklrOXJWVUZLWldVMlRXZGtlVEJYV0hRMWJscEVhVTEwU3pocGVtMXBTbGd5YzJkM1pVRmZlVk5tZEZFaSIsImV4cCI6bnVsbCwicHVyIjoiY29va2llLmZhX3VzZXJfc2Vzc2lvbl9rZXkifX0%3D--b3f76b2b656f73c1fb0da60566eaaffaba35f4b0; _fa_session_2=%2BQ9Gwe1bVWqEdl6rOxXAmDABr7rW%2FUU1LT%2FVEYF3s9oE%2B%2FAzCXGhjzZY7oG1SNUzAJc3xLJ4My4sDsjG9TCYlgURjxlFGYilvecpQgYrmxUgcpFYNC7S5dyO1W3fkLYEwh8MXF7HvlX%2F8ZfLJ5VeIRmGfgOaFht6i6rwFvtRB6fti7EItz3AK9ghwiKtsI0uohdWlNjYDVap9oKNV5QhTqKa%2FPq0L9%2Fyzj71eRoaDXq51nMWe%2Fqx%2FfBu8%2FhLCkvcjDZMpovs%2BnkjbK3YeOrh%2F5ddBoSy2FBh53kMZ2E41gV5zpWUUR2vrnVCo%2BbnLHhmMpKOd1oqtpP27y02JyHwzoyip%2FtaTYzD0pNJ8qLF%2BLTV68aoFy19mxrr%2B5dyPbdeVxRbEETkRf%2BhxkDmVV0nbR9jVXsQupumol9Q3iN7sQcos%2Btk%2F4FPc49tzUJyTO1BraX7%2ByQ%3D--ys2LouRQBzpTmfrG--%2By6LhuqzMHYHvHYDVMNRUQ%3D%3D\ 
[...]
```
</details>
This is to try and make sense of what's happening with these pending connections. It's ugly and difficult to read, but the longer we take to output this, the longer the connections have to resolve and mask the issue (i.e. end up reporting that they have resolved).